### PR TITLE
Modified run_steps()

### DIFF
--- a/modules/pipeliners.py
+++ b/modules/pipeliners.py
@@ -49,7 +49,7 @@ def add_step(name, cmd):
 
 def run_steps():
 
-    for step in steps:
+    for step in __steps:
         (name, cmd) = step
         system_call( name, cmd)
 


### PR DESCRIPTION
Changed 'steps' to '__steps' in for loop, since 'steps' does not exist, while global '__steps' contains the list of steps to be run.
